### PR TITLE
Add Go workflows

### DIFF
--- a/.github/workflows/go-security.yml
+++ b/.github/workflows/go-security.yml
@@ -1,0 +1,31 @@
+name: Go Security Check
+
+on:
+  workflow_call:
+
+jobs:
+  security:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Get security dependencies
+        run: go install github.com/securego/gosec/v2/cmd/gosec@latest
+
+      - name: Run Security Report
+        shell: bash
+        run: gosec -fmt yaml -out=security-report.yml -stdout ./...
+      - name: Output Security Report
+        run: |
+          (
+            echo '```yaml'
+            cat security-report.yml
+            echo ''
+            echo '```'
+          ) >> $GITHUB_STEP_SUMMARY
+        if: always()

--- a/.github/workflows/go-syntax.yml
+++ b/.github/workflows/go-syntax.yml
@@ -1,0 +1,26 @@
+name: Go Syntax Check
+
+on:
+  workflow_call:
+
+jobs:
+  syntax:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Go Format
+        run: |
+          GOFMT_OUTPUT=$(gofmt -l $(find . -path '*/vendor/*' -prune -o -name '*.go' -print))
+          if [ -n "$FMT_OUTPUT" ] ; then
+            echo 'The following files are not correctly formatted:'
+            echo "${GOFMT_OUTPUT}"
+            exit 1
+          fi
+
+      - name: Go Vet
+        run: go vet ./...

--- a/.github/workflows/go-syntax.yml
+++ b/.github/workflows/go-syntax.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Go Format
         run: |
           GOFMT_OUTPUT=$(gofmt -l $(find . -path '*/vendor/*' -prune -o -name '*.go' -print))
-          if [ -n "$FMT_OUTPUT" ] ; then
+          if [ -n "$GOFMT_OUTPUT" ] ; then
             echo 'The following files are not correctly formatted:'
             echo "${GOFMT_OUTPUT}"
             exit 1

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -1,0 +1,76 @@
+name: Go Test
+
+on:
+  workflow_call:
+    inputs:
+      enable-translate:
+        description: "True to make translations with 'make translate'"
+        type: boolean
+        default: false
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version-file: 'go.mod'
+      - name: Set up redis-server
+        uses: supercharge/redis-github-action@1.5.0
+        with:
+          redis-version: 5
+
+      - name: Test dependencies
+        run: |
+          go install github.com/jstemmer/go-junit-report/v2@latest
+          go install github.com/nicksnyder/go-i18n/goi18n@v1.10.1
+          go install github.com/axw/gocov/gocov@latest
+          go install github.com/matm/gocov-html/cmd/gocov-html@latest
+      - name: Create result directory
+        run: mkdir -p results
+      - name: Translations
+        run: make translate
+        if: ${{ inputs.enable-translate }}
+
+      - name: Test
+        shell: bash
+        run: go test -coverprofile=cp.out -race ./... 2>&1 | tee test.out
+      - name: Integration Test
+        shell: bash
+        run: go test -v -count=1 -tags integration -cover -race ./... 2>&1 | tee integration.out
+
+      - name: Test Junit report
+        run: |
+          [ ! -f test.out ] || go-junit-report < test.out > results/test-report.xml
+        if: always()
+      - name: Integration Test Junit report
+        run: |
+          [ ! -f integration.out ] || go-junit-report < integration.out > results/integration-report.xml
+        if: always()
+      - name: Test Summary
+        uses: test-summary/action@v2
+        with:
+          paths: |
+            results/*.xml
+        if: always()
+
+      - name: Coverage
+        run: |
+          gocov convert cp.out > gocov.out
+          gocov-html < gocov.out > cov-test.html
+      - name: Coverage summary
+        run: |
+          (
+            echo '## Coverage'
+            echo ''
+            gocov report < gocov.out | tail -n 1
+          ) >> $GITHUB_STEP_SUMMARY
+
+      - name: Upload test coverage
+        uses: actions/upload-artifact@v3
+        with:
+          name: Test-Coverage
+          path: cov-test.html

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -31,9 +31,11 @@ jobs:
       - name: Test dependencies
         run: |
           go install github.com/jstemmer/go-junit-report/v2@latest
-          go install github.com/nicksnyder/go-i18n/goi18n@v1.10.1
           go install github.com/axw/gocov/gocov@latest
           go install github.com/matm/gocov-html/cmd/gocov-html@latest
+      - name: Translation dependencies
+        run: go install github.com/nicksnyder/go-i18n/goi18n@v1.10.1
+        if: ${{ inputs.enable-translate }}
       - name: Create result directory
         run: mkdir -p results
       - name: Translations

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Test dependencies
         run: |
-          go install github.com/jstemmer/go-junit-report/v2@latest
+          go install github.com/joschi/go-junit-report/v2/cmd/go-junit-report@latest
           go install github.com/axw/gocov/gocov@latest
           go install github.com/matm/gocov-html/cmd/gocov-html@latest
       - name: Translation dependencies

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -44,9 +44,13 @@ jobs:
 
       - name: Test
         shell: bash
+        env:
+          TZ: ''
         run: go test -coverprofile=cp.out -race ./... 2>&1 | tee test.out
       - name: Integration Test
         shell: bash
+        env:
+          TZ: ''
         run: go test -v -count=1 -tags integration -cover -race ./... 2>&1 | tee integration.out
 
       - name: Test Junit report

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -31,8 +31,6 @@ jobs:
       - name: Test dependencies
         run: |
           go install github.com/joschi/go-junit-report/v2/cmd/go-junit-report@latest
-          go install github.com/axw/gocov/gocov@latest
-          go install github.com/matm/gocov-html/cmd/gocov-html@latest
       - name: Translation dependencies
         run: go install github.com/nicksnyder/go-i18n/goi18n@v1.10.1
         if: ${{ inputs.enable-translate }}
@@ -70,14 +68,14 @@ jobs:
 
       - name: Coverage
         run: |
-          gocov convert cp.out > gocov.out
-          gocov-html < gocov.out > cov-test.html
+          go tool cover -func=cp.out -o=gocov.out
+          go tool cover -html=cp.out -o=cov-test.html
       - name: Coverage summary
         run: |
           (
             echo '## Coverage'
             echo ''
-            gocov report < gocov.out | tail -n 1
+            tail -n 1 gocov.out | column -t
           ) >> $GITHUB_STEP_SUMMARY
 
       - name: Upload test coverage

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -3,6 +3,10 @@ name: Go Test
 on:
   workflow_call:
     inputs:
+      enable-redis:
+        description: "True to start redis server"
+        type: boolean
+        default: false
       enable-translate:
         description: "True to make translations with 'make translate'"
         type: boolean
@@ -22,6 +26,7 @@ jobs:
         uses: supercharge/redis-github-action@1.5.0
         with:
           redis-version: 5
+        if: ${{ inputs.enable-redis }}
 
       - name: Test dependencies
         run: |

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ As is customary for GitHub Actions, we provide release tags for you to reference
 
 ## Usage
 
+### ECR Push
+
 ```yml
 jobs:
   ecr-push:
@@ -25,4 +27,26 @@ CI_DOCKER_IMAGE=
 .PHONY: ci-docker-build
 ci-docker-build:
 	docker build --tag "$(CI_DOCKER_IMAGE)" .
+```
+
+### Go Tests
+
+Go lang test, syntax check, security check:
+
+```yml
+name: Go
+
+on: [push]
+
+jobs:
+  syntax:
+    uses: Fatsoma/reusable-actions/.github/workflows/go-syntax.yml@v1
+
+  test:
+    uses: Fatsoma/reusable-actions/.github/workflows/go-test.yml@v1
+    with:
+      enable-translate: true
+
+  security:
+    uses: Fatsoma/reusable-actions/.github/workflows/go-security.yml@v1
 ```


### PR DESCRIPTION
https://fatsoma.atlassian.net/browse/PLAT-1203

Add reusable GitHub workflow for go tests and syntax / security checks.

Sample usage (once tagged with `v1`):

```yml
name: Go

on: [push]

jobs:
  syntax:
    uses: Fatsoma/reusable-actions/.github/workflows/go-syntax.yml@v1

  test:
    uses: Fatsoma/reusable-actions/.github/workflows/go-test.yml@v1
    with:
      enable-translate: true

  security:
    uses: Fatsoma/reusable-actions/.github/workflows/go-security.yml@v1
```