### PR TITLE
feat: use bundled rubocop

### DIFF
--- a/.github/workflows/ruby-lint.yml
+++ b/.github/workflows/ruby-lint.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    env:
+      BUNDLE_RUBYGEMS__PKG__GITHUB__COM: ${{ secrets.BUNDLE_RUBYGEMS__PKG__GITHUB__COM }}
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ruby-lint.yml
+++ b/.github/workflows/ruby-lint.yml
@@ -2,6 +2,10 @@ name: Ruby Lint
 
 on:
   workflow_call:
+    secrets:
+      BUNDLE_RUBYGEMS__PKG__GITHUB__COM:
+        description: "The GitHub token to use for private gem sources"
+        required: true
 
 jobs:
   lint:

--- a/.github/workflows/ruby-lint.yml
+++ b/.github/workflows/ruby-lint.yml
@@ -35,6 +35,5 @@ jobs:
           CHANGED_RUBY_FILES: ${{ steps.changed-files.outputs.CHANGED_RUBY_FILES }}
         run: |
           if [ -n "$CHANGED_RUBY_FILES" ]; then
-            gem install rubocop
-            rubocop $CHANGED_RUBY_FILES
+            bundle exec rubocop $CHANGED_RUBY_FILES
           fi


### PR DESCRIPTION
Allow access to private RuboCop config gem.

Updates workflow to use personal access tokens to access RuboCop configuration from private repository. Enables fetching of private gems.

### Todo

- Re-tag workflow once this is approved.